### PR TITLE
feat: add in Time input components

### DIFF
--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 
-import Input from "./shared/Input";
 import TimeDisplay from "./shared/TimeDisplay";
 import { TimeStructure } from "./Timer";
 
@@ -13,9 +12,6 @@ export default function Time({
   time: TimeStructure;
   setTime: React.Dispatch<React.SetStateAction<TimeStructure>>;
 }) {
-  const [isEditingSeconds, setIsEditingSeconds] = useState<boolean>(false);
-  const [isEditingMinutes, setIsEditingMinutes] = useState<boolean>(false);
-
   const [errorMessage, setErrorMessage] = useState<string>("");
 
   const handleTimeChange = (

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -22,20 +22,35 @@ export default function Time({
 
     const inputValue = e.target.value;
 
-    // Validate and constrain values
-    if (Number(inputValue) >= 60) {
-      setErrorMessage("Seconds must be less than 60");
-      return;
+    // Validate and constrain values based on the variant
+    if (variant === "seconds") {
+      if (Number(inputValue) >= 60) {
+        setErrorMessage("Seconds must be less than 60");
+        return;
+      }
+      if (Number(inputValue) < 0) {
+        setErrorMessage("Seconds must be greater than or equal to 0");
+        return;
+      }
+    } else if (variant === "minutes") {
+      if (Number(inputValue) > 999) { // Adjust the upper limit as needed
+        setErrorMessage("Minutes must be less than or equal to 999");
+        return;
+      }
+      if (Number(inputValue) < 0) {
+        setErrorMessage("Minutes must be greater than or equal to 0");
+        return;
+      }
     }
 
     // Allow incomplete input during editing
     if (isNaN(Number(inputValue))) {
-      setErrorMessage("Enter a valid number between 0 and 59");
+      setErrorMessage(
+        variant === "seconds"
+          ? "Enter a valid number between 0 and 59"
+          : "Enter a valid number between 0 and 999"
+      );
       return; // Let user continue typing
-    }
-    if (Number(inputValue) < 0) {
-      setErrorMessage("Seconds must be greater than or equal to 0");
-      return;
     }
 
     setTime({ ...time, [variant]: Number(inputValue) });

--- a/src/components/Time.tsx
+++ b/src/components/Time.tsx
@@ -1,11 +1,66 @@
+import { useState } from "react";
+
+import Input from "./shared/Input";
+import TimeDisplay from "./shared/TimeDisplay";
 import { TimeStructure } from "./Timer";
 
-export default function Time({ time }: { time: TimeStructure }) {
-  /**
-   * This component will receive the time remaining from the Timer component
-   * It will display the time in a visual format
-   * It will visually show when time is up with an emphasised styling
-   * This will handle the setting of the time by clicking on the time
-   */
-  return <></>;
+export type TimeVariants = "seconds" | "minutes";
+
+export default function Time({
+  time,
+  setTime,
+}: {
+  time: TimeStructure;
+  setTime: React.Dispatch<React.SetStateAction<TimeStructure>>;
+}) {
+  const [isEditingSeconds, setIsEditingSeconds] = useState<boolean>(false);
+  const [isEditingMinutes, setIsEditingMinutes] = useState<boolean>(false);
+
+  const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const handleTimeChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    variant: TimeVariants
+  ) => {
+    setErrorMessage("");
+
+    const inputValue = e.target.value;
+
+    // Validate and constrain values
+    if (Number(inputValue) >= 60) {
+      setErrorMessage("Seconds must be less than 60");
+      return;
+    }
+
+    // Allow incomplete input during editing
+    if (isNaN(Number(inputValue))) {
+      setErrorMessage("Enter a valid number between 0 and 59");
+      return; // Let user continue typing
+    }
+    if (Number(inputValue) < 0) {
+      setErrorMessage("Seconds must be greater than or equal to 0");
+      return;
+    }
+
+    setTime({ ...time, [variant]: Number(inputValue) });
+  };
+
+  return (
+    <section className='flex flex-col items-center justify-center w-full gap-2'>
+      <article className='flex flex-row items-center justify-center w-full gap-1'>
+        <TimeDisplay
+          time={time.minutes}
+          handleTimeChange={handleTimeChange}
+          variant='minutes'
+        />{" "}
+        <h1>:</h1>
+        <TimeDisplay
+          time={time.seconds}
+          handleTimeChange={handleTimeChange}
+          variant='seconds'
+        />
+      </article>
+      {errorMessage && <p>{errorMessage}</p>}{" "}
+    </section>
+  );
 }

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -9,12 +9,12 @@ export interface TimeStructure {
 }
 export default function Timer() {
   const [time, setTime] = useState<TimeStructure>({
-    minutes: 30,
-    seconds: 30,
+    minutes: 0,
+    seconds: 0,
   });
   const [timeElapsed, setTimeElapsed] = useState<number>(0);
   const [progress, setProgress] = useState(0);
-  const [isRunning, setIsRunning] = useState(true);
+  const [isRunning, setIsRunning] = useState(false);
 
   const progressGradient = useMemo(() => {
     const yellow = "#fffb00";
@@ -76,7 +76,7 @@ export default function Timer() {
           id='progress-inner-bar'
           className='w-[70vmin] h-[70vmin] bg-[#11099c] flex flex-col items-center justify-center rounded-full'
         >
-          <Time time={time} />
+          <Time time={time} setTime={setTime} />
           <div className='flex gap-4 mt-4'>
             <Button action={isRunning ? "stop" : "start"} variant='primary' />
             <Button action='reset' variant='secondary' />

--- a/src/components/shared/Input.tsx
+++ b/src/components/shared/Input.tsx
@@ -1,0 +1,29 @@
+export default function Input({
+  name,
+  value,
+  handleChange,
+  onBlur,
+}: {
+  name: string;
+  value: string;
+  handleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onBlur?: () => void;
+}) {
+  return (
+    <div className='w-min min-w-[54px]'>
+      <input
+        id={name}
+        name={name}
+        type='text'
+        onChange={handleChange}
+        value={!value || value === "0" ? "" : value}
+        onFocus={(e) => e.target.select()}
+        onBlur={onBlur}
+        pattern='[0-9]{1,2}'
+        aria-live='polite'
+        aria-label={`${name} input`}
+        className='outline-none w-full text-5xl border-none bg-transparent'
+      />
+    </div>
+  );
+}

--- a/src/components/shared/TimeDisplay.tsx
+++ b/src/components/shared/TimeDisplay.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+
+import { TimeVariants } from "../Time";
+import Input from "./Input";
+
+export default function TimeDisplay({
+  time,
+  handleTimeChange,
+  variant,
+}: {
+  time: number;
+  handleTimeChange: (
+    e: React.ChangeEvent<HTMLInputElement>,
+    variant: TimeVariants
+  ) => void;
+  variant: TimeVariants;
+}) {
+  const [canEdit, setCanEdit] = useState<boolean>(false);
+
+  return !canEdit ? (
+    <h1
+      onClick={() => {
+        setCanEdit(true);
+      }}
+      className='text-5xl cursor-pointer'
+      role='button'
+      aria-label={`Edit ${variant}`}
+    >
+      {time || "00"}
+    </h1>
+  ) : (
+    <Input
+      name={variant}
+      value={`${time}` || ""}
+      handleChange={(e) => {
+        handleTimeChange(e, variant);
+      }}
+      onBlur={() => setCanEdit(false)}
+    />
+  );
+}


### PR DESCRIPTION
This pull request introduces significant updates to the `Time` and `Timer` components, enabling users to edit and validate time input directly. It also adds reusable components to improve code modularity and maintainability. Below is a summary of the most important changes grouped by theme:

### Enhancements to Time Editing and Validation:
* Updated `Time` component (`src/components/Time.tsx`) to allow users to edit time values (minutes and seconds) with validation for valid ranges (e.g., seconds must be between 0 and 59). Added error messages for invalid inputs and integrated with the `setTime` state handler.
* Modified `Timer` component (`src/components/Timer.tsx`) to pass the `setTime` handler to the `Time` component, enabling real-time updates to the timer state. Initial time values were also changed to 0 minutes and 0 seconds, and the timer is now initialized as not running. [[1]](diffhunk://#diff-b73f9e966057a8ee907bf13e5247abda3728475cea6668ee4bb55f91c8447391L12-R17) [[2]](diffhunk://#diff-b73f9e966057a8ee907bf13e5247abda3728475cea6668ee4bb55f91c8447391L79-R79)

### New Reusable Components:
* Added a new `Input` component (`src/components/shared/Input.tsx`) for handling text input with customizable props such as `name`, `value`, and `onChange`. This component includes accessibility features like `aria-live` and `aria-label`.
* Introduced a `TimeDisplay` component (`src/components/shared/TimeDisplay.tsx`) to toggle between a static time display and an editable input field. It uses the new `Input` component and manages its own edit state.

### Further Work

I will need to improve the error message handling in future, right now text just pops up below the timer