### PR TITLE
refactor: move Timer progress circle to own component

### DIFF
--- a/src/components/ProgressCircle.tsx
+++ b/src/components/ProgressCircle.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from "react";
+
+interface ProgressCircleProps {
+  progress: number;
+  children: ReactNode;
+}
+
+export default function ProgressCircle({
+  progress,
+  children,
+}: ProgressCircleProps) {
+  // Calculate gradient for progress visualization
+  const yellow = "#fffb00";
+  const blue = "#11099c";
+  const convertProgressToDeg = (100 - progress) * 3.6;
+
+  const progressGradient = `conic-gradient(
+    ${yellow} 0deg,
+    ${yellow} ${convertProgressToDeg}deg,
+    ${blue} ${convertProgressToDeg}deg,
+    ${blue} 360deg
+  )`;
+
+  return (
+    <div
+      id='progress-outer-bar'
+      className='w-[75vmin] h-[75vmin] flex flex-col items-center justify-center rounded-full'
+      style={{
+        background: progressGradient,
+      }}
+    >
+      <div
+        id='progress-inner-bar'
+        className='w-[70vmin] h-[70vmin] bg-[#11099c] flex flex-col items-center justify-center gap-3 rounded-full'
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Timer.tsx
+++ b/src/components/Timer.tsx
@@ -1,12 +1,14 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import Actions from "./Actions";
+import ProgressCircle from "./ProgressCircle";
 import Time from "./Time";
 
 export interface TimeStructure {
   minutes: number;
   seconds: number;
 }
+
 export default function Timer() {
   const [time, setTime] = useState<TimeStructure>({
     minutes: 0,
@@ -15,19 +17,6 @@ export default function Timer() {
   const [timeElapsed, setTimeElapsed] = useState<number>(0);
   const [progress, setProgress] = useState(100);
   const [isRunning, setIsRunning] = useState(false);
-
-  const progressGradient = useMemo(() => {
-    const yellow = "#fffb00";
-    const blue = "#11099c";
-    const convertProgressToDeg = (100 - progress) * 3.6;
-
-    return `conic-gradient(
-    ${yellow} 0deg,
-    ${yellow} ${convertProgressToDeg}deg,
-    ${blue} ${convertProgressToDeg}deg,
-    ${blue} 360deg
-  )`;
-  }, [progress]);
 
   const convertTimeToSeconds = useCallback((time: TimeStructure) => {
     return time.minutes * 60 + time.seconds;
@@ -81,26 +70,15 @@ export default function Timer() {
 
   return (
     <section className='flex flex-col items-center gap-2 justify-center w-full h-full'>
-      <div
-        id='progress-outer-bar'
-        className='w-[75vmin] h-[75vmin] flex flex-col items-center justify-center rounded-full'
-        style={{
-          background: `${progressGradient}`,
-        }}
-      >
-        <div
-          id='progress-inner-bar'
-          className='w-[70vmin] h-[70vmin] bg-[#11099c] flex flex-col items-center justify-center gap-3 rounded-full'
-        >
-          <Time time={time} setTime={setTime} />
-          <Actions
-            isRunning={isRunning}
-            onStart={handleStart}
-            onStop={handleStop}
-            onReset={handleReset}
-          />
-        </div>
-      </div>
+      <ProgressCircle progress={progress}>
+        <Time time={time} setTime={setTime} />
+        <Actions
+          isRunning={isRunning}
+          onStart={handleStart}
+          onStop={handleStop}
+          onReset={handleReset}
+        />
+      </ProgressCircle>
     </section>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -13,13 +13,13 @@
 
   margin: 0 auto;
   text-align: center;
+  background-color: #11099c;
 }
 
 body {
   margin: 0;
   display: flex;
   place-items: center;
-  background-color: #11099c;
   color: #fffb00;
   font-family: "Ubuntu", system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", Roboto, Oxygen, Cantarell, "Open Sans", "Helvetica Neue",


### PR DESCRIPTION
This pull request refactors the progress visualization logic by introducing a reusable `ProgressCircle` component and simplifies the `Timer` component by delegating progress rendering to this new component. Additionally, minor CSS adjustments were made to improve maintainability.

### Refactoring and Reusability:

* Introduced a new `ProgressCircle` component in `src/components/ProgressCircle.tsx` to encapsulate the logic for rendering a circular progress bar with a conic gradient. This component accepts `progress` and `children` as props.
* Updated the `Timer` component in `src/components/Timer.tsx` to use the new `ProgressCircle` component, removing the inline gradient calculation and related JSX structure. [[1]](diffhunk://#diff-b73f9e966057a8ee907bf13e5247abda3728475cea6668ee4bb55f91c8447391L19-L31) [[2]](diffhunk://#diff-b73f9e966057a8ee907bf13e5247abda3728475cea6668ee4bb55f91c8447391L84-R81)

### Simplification and Cleanup:

* Removed the unused `useMemo` logic for progress gradient calculation from the `Timer` component, as it is now handled by the `ProgressCircle` component.

### CSS Adjustments:

* Moved the `background-color: #11099c` rule from the `body` selector to a shared container selector in `src/index.css` for better maintainability.